### PR TITLE
Bumps the framework and generator versions to 0.21.0.

### DIFF
--- a/Sources/MockingbirdCli/Info.plist
+++ b/Sources/MockingbirdCli/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.20.0</string>
+	<string>0.21.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/Sources/MockingbirdCommon/Version.swift
+++ b/Sources/MockingbirdCommon/Version.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// The current version of Mockingbird.
-public let mockingbirdVersion = Version(shortString: "0.20.0")
+public let mockingbirdVersion = Version(shortString: "0.21.0")
 
 /// A comparable semantic version.
 public struct Version: Comparable, CustomStringConvertible {

--- a/Sources/MockingbirdFramework/Info.plist
+++ b/Sources/MockingbirdFramework/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.20.0</string>
+	<string>0.21.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/Sources/MockingbirdGenerator/Info.plist
+++ b/Sources/MockingbirdGenerator/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.20.0</string>
+	<string>0.21.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
Prepare for new release by bumping versions
