### PR TITLE
Fix corrupted output

### DIFF
--- a/Sources/MockingbirdCli/Info.plist
+++ b/Sources/MockingbirdCli/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.23.0</string>
+	<string>0.24.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/Sources/MockingbirdCommon/Version.swift
+++ b/Sources/MockingbirdCommon/Version.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// The current version of Mockingbird.
-public let mockingbirdVersion = Version(shortString: "0.23.0")
+public let mockingbirdVersion = Version(shortString: "0.24.0")
 
 /// A comparable semantic version.
 public struct Version: Comparable, CustomStringConvertible {

--- a/Sources/MockingbirdFramework/Info.plist
+++ b/Sources/MockingbirdFramework/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.23.0</string>
+	<string>0.24.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/Sources/MockingbirdGenerator/Info.plist
+++ b/Sources/MockingbirdGenerator/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.23.0</string>
+	<string>0.24.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
Actually fixes the corrected output this time. Verified by replicated the problem with a local release build, fixing it, and verifying that it was fixed.

The issue was an incorrect usage of `rawData.withUnsafeBytes { ... }`, where the bytes passed into the closure where returned out of the closure and then used. I suspect that a release optimisation freed the memory of rawData after it's last usage in the function, which zero-ed the memory of the unsafe bytes before it could be written to the stream. Moving the write operation into the `withUnsafeBytes { ... }` closure fixed the issue.

- bumped version for release