### PR TITLE
fix file group exception handling

### DIFF
--- a/Sources/MockingbirdCli/Info.plist
+++ b/Sources/MockingbirdCli/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.25.0</string>
+	<string>0.26.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/Sources/MockingbirdCommon/Version.swift
+++ b/Sources/MockingbirdCommon/Version.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// The current version of Mockingbird.
-public let mockingbirdVersion = Version(shortString: "0.25.0")
+public let mockingbirdVersion = Version(shortString: "0.26.0")
 
 /// A comparable semantic version.
 public struct Version: Comparable, CustomStringConvertible {

--- a/Sources/MockingbirdFramework/Info.plist
+++ b/Sources/MockingbirdFramework/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.25.0</string>
+	<string>0.26.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/Sources/MockingbirdGenerator/Info.plist
+++ b/Sources/MockingbirdGenerator/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.25.0</string>
+	<string>0.26.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Sources/MockingbirdGenerator/Parser/Project/PBXTarget+Target.swift
+++ b/Sources/MockingbirdGenerator/Parser/Project/PBXTarget+Target.swift
@@ -47,6 +47,8 @@ extension PBXTarget: Target {
         guard let fullPath = try? group.fullPath(sourceRoot: sourceRoot) else { return [] }
         
         let exceptions = Set(group.exceptions?
+          // Only consider exceptions that apply to this target.
+          .filter { $0.target == self }
           .flatMap { $0.membershipExceptions?.map { fullPath + Path($0) } ?? [] }
           .map { $0.absolute() } ?? [])
         


### PR DESCRIPTION
This PR fixes a bug where swift files in folders that were shared across multiple targets where not parsed by Mocking and prevented generation of mocks in those files.
- only filter files listen in exceptions if the exception groups target is the current target
- bump version
